### PR TITLE
Allow None for discovery setter

### DIFF
--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -276,7 +276,7 @@ class LEDENETDevice:
         return self._discovery
 
     @discovery.setter
-    def discovery(self, value: FluxLEDDiscovery) -> None:
+    def discovery(self, value: FluxLEDDiscovery | None) -> None:
         """Set the discovery data."""
         self._discovery = value
 


### PR DESCRIPTION
`self._discovery` is typed as `FluxLEDDiscovery | None`, so all code using it needs to handle `None´ already. Allow assignments with `None` as well. If desired, the `discovery` property could be fully replaced with a normal assignment.

https://github.com/Danielhiversen/flux_led/blob/cbbad4dff97a676409e38371224438aaefdfcb61/flux_led/base_device.py#L273-L276

Ref: https://github.com/home-assistant/core/pull/136544#discussion_r1929646718