### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     author="Daniel Hjelseth Høyer",
     author_email="mail@dahoiv.net",
     url="https://github.com/Danielhiversen/flux_led",
-    license="LGPLv3+",
+    license="LGPL-3.0-or-later",
     include_package_data=True,
     package_data={"flux_led": ["py.typed"]},
     keywords=[


### PR DESCRIPTION
Setuptools doesn't support PEP 639 just yet. However, it's still possible to use the official SPDX identifiers to better describe the license.

https://spdx.org/licenses/LGPL-3.0-or-later.html