### PR TITLE
Handle speed not being in delay format for newer 0x35 devices

### DIFF
--- a/flux_led/base_device.py
+++ b/flux_led/base_device.py
@@ -1063,7 +1063,7 @@ class LEDENETDevice:
     @property
     def speed(self) -> int:
         assert self.raw_state is not None
-        if self.protocol in ADDRESSABLE_PROTOCOLS:
+        if self._protocol is not None and not self._protocol.speed_is_delay:
             return self.raw_state.speed
         if self.protocol in CHRISTMAS_EFFECTS_PROTOCOLS:
             return utils.delayToSpeed(self.raw_state.green)

--- a/flux_led/protocol.py
+++ b/flux_led/protocol.py
@@ -417,6 +417,11 @@ class ProtocolBase:
         super().__init__()
 
     @property
+    def speed_is_delay(self) -> bool:
+        """If True the speed is a delay."""
+        return True
+
+    @property
     def requires_turn_on(self) -> bool:
         """If True the device must be turned on before setting level/patterns/modes."""
         return True
@@ -1409,6 +1414,11 @@ class ProtocolLEDENET25Byte(ProtocolLEDENET9Byte):
     level_write_modes = LevelWriteModeData(ALL=0x00, COLORS=0xA1, WHITES=0xB1)
 
     @property
+    def speed_is_delay(self) -> bool:
+        """If True the speed is a delay."""
+        return False
+
+    @property
     def name(self) -> str:
         """The name of the protocol."""
         return PROTOCOL_LEDENET_25BYTE
@@ -1498,6 +1508,11 @@ class ProtocolLEDENETAddressableBase(ProtocolLEDENET9Byte):
     def timer_len(self) -> int:
         """Return a single timer len."""
         return 14
+
+    @property
+    def speed_is_delay(self) -> bool:
+        """If True the speed is a delay."""
+        return False
 
 
 class ProtocolLEDENETAddressableA1(ProtocolLEDENETAddressableBase):
@@ -2386,6 +2401,11 @@ class ProtocolLEDENETCCTWrapped(ProtocolLEDENETCCT):
 
 
 class ProtocolLEDENETAddressableChristmas(ProtocolLEDENETAddressableBase):
+    @property
+    def speed_is_delay(self) -> bool:
+        """If True the speed is a delay in ms."""
+        return True
+
     def construct_state_query(self) -> bytearray:
         """The bytes to send for a query request."""
         return self.construct_wrapped_message(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -873,6 +873,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.protocol, PROTOCOL_LEDENET_25BYTE)
         self.assertEqual(light.model_num, 0x35)
         self.assertEqual(light.version_num, 10)
+        self.assertEqual(light.speed, 64)
 
         light.setRgb(255, 100, 50)
         self.assertEqual(mock_send.call_count, 2)


### PR DESCRIPTION
For the 25 byte protocol speed is the actual speed not in delay format.
